### PR TITLE
Allows for the hosts to be specified via the commandline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,12 +17,16 @@ Via PyPI::
 
   pip install cnx-rex-redirects
 
-Developer Usage
----------------
+Usage
+-----
 
-Usage::
+Usage help::
 
   rex_redirect --help
+
+Example usage::
+
+  rex_redirects --openstax-host staging.openstax.org --archive-host archive-staging.cnx.org -o - generate-cnx-uris-for-rex-books > uris.txt
 
 License
 -------

--- a/rex_redirects.py
+++ b/rex_redirects.py
@@ -125,9 +125,9 @@ def write_nginx_map(uri_map, out):
 
 
 @click.command()
-@click.option('-o', '--output', type=click.File(mode='w'))
 @click.pass_context
-def update_rex_redirects(ctx, output):
+def update_rex_redirects(ctx):
+    output = ctx.parent.params['output']
     release_json_url = get_rex_release_json_url(ctx.parent.params['openstax_host'])
     release_data = requests.get(release_json_url).json()
     books = [book for book in release_data['books']]
@@ -174,9 +174,8 @@ def generate_cnx_uris(book_id):
 
 
 @click.command()
-@click.option('-o', '--output', type=click.File(mode='w'))
 @click.pass_context
-def generate_cnx_uris_for_rex_books(ctx, output):
+def generate_cnx_uris_for_rex_books(ctx):
     """This outputs a list of CNX URIs to stdout.
     These are URIs that should redirect to REX.
 
@@ -184,6 +183,7 @@ def generate_cnx_uris_for_rex_books(ctx, output):
     They exercise a number of variations the URI can be represented as.
 
     """
+    output = ctx.parent.params['output']
     release_json_url = get_rex_release_json_url(ctx.parent.params['openstax_host'])
     release_data = requests.get(release_json_url).json()
     for book in release_data['books']:
@@ -194,6 +194,7 @@ def generate_cnx_uris_for_rex_books(ctx, output):
 @click.group()
 @click.option('--openstax-host', envvar='OPENSTAX_HOST', default='openstax.org')
 @click.option('--archive-host', envvar='ARCHIVE_HOST', default='archive.cnx.org')
+@click.option('-o', '--output', type=click.File(mode='w'))
 def main(*args, **kwargs):
     pass
 

--- a/rex_redirects.py
+++ b/rex_redirects.py
@@ -12,7 +12,6 @@ requests.mount('https://', adapter)
 
 here = Path(__file__).parent
 CNX_HOST = 'archive.cnx.org'
-MAP_FILEPATH = here.resolve().parent / 'roles/webview/files/etc/nginx/uri-maps/rex-uris.map'
 
 
 def get_rex_release_json_url(host):


### PR DESCRIPTION
This gives the user the option to specify which hosts to use when generating the redirects or uris.

(Note, I was working on this yesterday and just putting it out there today.)