### PR TITLE
Fix composite page redirects and setup.py

### DIFF
--- a/rex_redirects.py
+++ b/rex_redirects.py
@@ -1,8 +1,13 @@
 import click
-import requests
+import requests as requestslib
 from pathlib import Path
 
 from cnxcommon import ident_hash
+
+
+requests = requestslib.Session()
+adapter = requestslib.adapters.HTTPAdapter(max_retries=5)
+requests.mount('https://', adapter)
 
 
 here = Path(__file__).parent

--- a/rex_redirects.py
+++ b/rex_redirects.py
@@ -57,7 +57,7 @@ def cnx_uri_regex(book, page):
     if page is None:
         uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?(/[-%\w\d]+)?$"
     else:
-        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?:({page['id']}|{page['short_id']})(@[\d]+)?(/[-%\w\d]+)?$"
+        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?:({page['id']}|{page['short_id']})(@[.\d]+)?(/[-%\w\d]+)?$"
     return uri_regex
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     author='OpenStax',
     url="https://github.com/openstax",
     license='LGPL',
+    py_modules=['rex_redirects'],
     entry_points="""\
     [console_scripts]
     rex_redirects = rex_redirects:main


### PR DESCRIPTION
- Allow collection version as page version in CNX URL regexes used in REX redirects


- Include rex_redirects.py in distribution

  After installing cnx-rex-redirects with pip:
  
  ```
  pip install git+https://github.com/openstax/cnx-rex-redirects.git@fix-composite-pages
  ```
  
  it's not possible to run `rex_redirects`:
  
  ```
  Traceback (most recent call last):
    File "py3/bin/rex_redirects", line 6, in <module>
      from rex_redirects import main
  ModuleNotFoundError: No module named 'rex_redirects'
  ```
  
  I couldn't find `rex_redirects.py` in `lib/python3.6/site-packages`.
  
  Adding `py_modules=['rex_redirects']` should work for single python file
  modules.

