### PR TITLE
Downgrade requests from 2.22.0 to 2.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click==7.0
 cnx-common==1.2.2
-requests==2.22.0
+requests==2.20.1


### PR DESCRIPTION
We are using this package to generate rex redirects urls for testing in
cnx-automation, but cnx-automation is using eyes-core `4.0.7` which
restricts requests to `<2.21.0,>=2.1.0`.  So we have to downgrade
requests in cnx-rex-redirects for it to install in cnx-automation.

---

I'm hoping for a different resolution instead... but for now, I'll use this branch in cnx-automation.