### PR TITLE
Add check for query parameters on regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.6"
+script:
+  - python -m unittest
+notifications:
+  email: false

--- a/rex_redirects.py
+++ b/rex_redirects.py
@@ -59,10 +59,15 @@ def rex_uri(book, page):
 
 
 def cnx_uri_regex(book, page):
+    # We want to match any query string, with the exception of if it's
+    # ?minimal=true as the latter is used to avoid redirects for our Android
+    # applications: https://github.com/openstax/cnx/issues/343
+    query_params_regex = r"(\?(?!.*minimal=true)(.+=.+[&]?)+)?"
+
     if page is None:
-        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?(/[-%\w\d]+)?$"
+        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?(/[-%\w\d]+)?{query_params_regex}$"
     else:
-        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?:({page['id']}|{page['short_id']})(@[.\d]+)?(/[-%\w\d]+)?$"
+        uri_regex = f"/contents/({book['id']}|{book['short_id']})(@[.\d]+)?:({page['id']}|{page['short_id']})(@[.\d]+)?(/[-%\w\d]+)?{query_params_regex}$"
     return uri_regex
 
 

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,53 @@
+import unittest
+import re
+from rex_redirects import cnx_uri_regex
+
+class TestUriRegex(unittest.TestCase):
+    def setUp(self):
+        self.book = {
+            "id": "book-long-id",
+            "short_id": "bookshortid"
+        }
+        self.page = {
+            "id": "page-long-id",
+            "short_id": "pageshortid"
+        }
+        self.base_uri = "/contents/bookshortid:pageshortid/slug"
+
+    def test_no_query_string_redirect(self):
+        """Baseline test to ensure redirects match as expected when no query
+        parameters are present
+        """
+        regex = cnx_uri_regex(self.book, self.page)
+        map_redirect = re.compile(regex)
+
+        self.assertRegex(f"{self.base_uri}", map_redirect)
+
+    def test_android_no_redirect(self):
+        """All requests for REX books that come from the Android App
+        should continue to pass through to the cnx site (these requests
+        are indicated by the attachment of the query-string: `?minimal=true`)
+        https://github.com/openstax/cnx/issues/343
+        """
+        regex = cnx_uri_regex(self.book, self.page)
+        map_redirect = re.compile(regex)
+
+        self.assertNotRegex(f"{self.base_uri}?minimal=true", map_redirect)
+        self.assertNotRegex(
+            f"{self.base_uri}?utm_campaign=Campaign&minimal=true&utm_source=Source",
+            map_redirect
+        )
+        self.assertNotRegex(
+            f"{self.base_uri}?utm_campaign=Campaign&utm_source=Source&minimal=true",
+            map_redirect
+        )
+
+    def test_query_string_redirect(self):
+        """Requests with query parameters should still redirect
+        https://github.com/openstax/cnx/issues/921
+        """
+        regex = cnx_uri_regex(self.book, self.page)
+        map_redirect = re.compile(regex)
+
+        query_params = "utm_source=Source&utm_medium=Medium&utm_campaign=Campaign"
+        self.assertRegex(f"{self.base_uri}?{query_params}", map_redirect)


### PR DESCRIPTION
It was found that redirects did not get mapped as expected when the
request URIs included query parameters. At the same time, the Android
application relies on redirects to REX not occuring when a URI has a
query parameter of `?minimal=true`. This update to the regex match
string should meet both of these needs.